### PR TITLE
Modified the dependencies position

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,9 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_credit_card: ^0.1.3
+  stripe_payment: ^1.0.7
+  http: ^0.11.3+17
+  progress_dialog: ^1.2.2
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -28,9 +31,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  stripe_payment: ^1.0.7
-  http: ^0.11.3+17
-  progress_dialog: ^1.2.2
+ 
 
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
The dependencies should be under dependencies header not under dev_dependencies. As the dev dependencies are removed in release mode